### PR TITLE
Change self_update in grub.cfg to autoupdate SUSE installer

### DIFF
--- a/group_vars/all.yml.example
+++ b/group_vars/all.yml.example
@@ -24,6 +24,7 @@ VENV_PYTHON: "/path/to/python/venv/that/has/the/modules/you/need"
 
 install_sys: "tftp://{{ TFTP_SERVER }}/{{ OS_TFTP_TAG }}/boot/{{ ARCH }}/root"
 install_url: "http://{{ INST_SERVER }}/{{ INST_PATH }}"
+installer_self_update: "{{ REPO_PROTO }}://{{ TFTP_SERVER }}/{{ INST_PATH|lower }}/Updates/SLE-INSTALLER/{{ OS_RELEASE }}-{{ OS_PATCH }}/{{ ARCH }}/update/"
 
 clustername: "cluster1"
 

--- a/templates/grub-net.cfg.j2
+++ b/templates/grub-net.cfg.j2
@@ -13,7 +13,7 @@ menuentry 'Installation' {
            ifcfg={{ node.provision.device }}=dhcp \
            install={{ REPO_URL }} \
            autoyast=tftp://{{ TFTP_SERVER }}/SLE-15-SP2-x86_64/autoyast/{{ node.name }}-autoinst.xml \
-           self_update=0 textmode=1
+           self_update={{ installer_self_update }} textmode=1
   echo 'Loading initrd ...'
   initrdefi $prefix/boot/x86_64/loader/initrd
 }


### PR DESCRIPTION
This change will enable the auto update feature of the SUSE autoyast installer. Updating fixes a crash that happens when an old installer tries to update newer modules during the install process.